### PR TITLE
Make plugnburn/edl work again with recent Python versions and Cat B35

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 capstone==4.0.2
 keystone==18.0.0
-pyusb==1.1.0
+pyusb==1.2.1
 pyserial==3.5


### PR DESCRIPTION
The firts commit updates pyusb to version 1.2.1 in order to support newer Python versions (tested with Python 3.10)

The second commit fixes a regression from https://github.com/plugnburn/edl/pull/1 for Cat B35. KaiOS Nokias / Alcatel Cingular Flip should still work by toggling '-non-standard-responses'

For the record, this is what I get with the first commit and without the second:

```
am@Host-002:~/github/edl$ python edl.py -loader 0x000940e100000000.mbn -printgpt

Qualcomm Sahara / Firehose Client (c) B.Kerler 2018-2019.


Using loader 0x000940e100000000.mbn ...
Waiting for the device
Device detected :)
Mode detected: Firehose
TargetName=MSM8909
MemoryName=eMMC
Version=1

Reading from physical partition 0, sector 0, sectors 32
Progress: |██████████████████████████████████████████████████| 100.0% Complete
Invalid or unknown GPT magic.

GPT Table:
-------------
Traceback (most recent call last):
  File "/home/am/github/edl/edl.py", line 419, in <module>
    main()
  File "/home/am/github/edl/edl.py", line 205, in main
    guid_gpt.print()
  File "/home/am/github/edl/Library/gpt.py", line 184, in print
    for partition in self.partentries:
AttributeError: 'gpt' object has no attribute 'partentries'. Did you mean: 'num_part_entries'?
```